### PR TITLE
Feat  :  DeleteProductResponseDto응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/online/shopping_back/controller/ProductController.java
+++ b/src/main/java/com/online/shopping_back/controller/ProductController.java
@@ -13,7 +13,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.online.shopping_back.dto.request.product.PatchProductRequestDto;
 import com.online.shopping_back.dto.request.product.PostProductRequestDto;
+import com.online.shopping_back.dto.response.product.PatchProductResponseDto;
 import com.online.shopping_back.dto.response.product.PostProductResponseDto;
 import com.online.shopping_back.service.ProductService;
 
@@ -36,4 +38,15 @@ public class ProductController {
         ResponseEntity<? super PostProductResponseDto>  response = productService.postProduct(dto, managerEmail, userNumber);
         return response;
     }    
+
+    @PatchMapping("/{userNumber}")
+    public ResponseEntity<? super PatchProductResponseDto> patchProduct(
+        @RequestBody @Valid PatchProductRequestDto dto,
+        @AuthenticationPrincipal String managerEmail,
+        @PathVariable("userNumber") Integer userNumber        
+    ){
+        ResponseEntity<? super PatchProductResponseDto> response = productService.patchProduct(dto, managerEmail, userNumber);
+        return response;
+    }
+
 }

--- a/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
@@ -34,5 +34,7 @@ public class DeleteProductResponseDto extends ResponseDto{
     public static ResponseEntity<ResponseDto> notExistProduct(){
         ResponseDto result = new ResponseDto(ResponseCode.NOT_FOUND_PRODUCT, ResponseMessage.NOT_FOUND_PRODUCT);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
-    }       
+    }   
+    
+    
 }

--- a/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
@@ -36,5 +36,4 @@ public class DeleteProductResponseDto extends ResponseDto{
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
     }   
     
-    
 }

--- a/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/product/DeleteProductResponseDto.java
@@ -1,0 +1,38 @@
+package com.online.shopping_back.dto.response.product;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.online.shopping_back.dto.response.ResponseCode;
+import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.ResponseMessage;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteProductResponseDto extends ResponseDto{
+    
+    private DeleteProductResponseDto(String code, String messsage){
+        super(code, messsage);
+    }
+
+    public static ResponseEntity<DeleteProductResponseDto> success(){
+        DeleteProductResponseDto result = new DeleteProductResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistManager(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_MANAGER, ResponseMessage.NOT_EXIST_MANAGER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+    
+    public static ResponseEntity<ResponseDto> notExistProduct(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_FOUND_PRODUCT, ResponseMessage.NOT_FOUND_PRODUCT);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }       
+}


### PR DESCRIPTION
DeleteProductResponseDto생성 및 상품정보 삭제시 실패와 성공에 대한 데이터 전송 객체(코드 및 메시지) 생성 및 성공시에만  DB 상품  테이블에 상품번호에 해당되는 정보 삭제하기 