### PR TITLE
Feat : PatchOrderProductResponseDto:응답 데이터를 전달하기 위한 데이터 전송 객체생성, OrderProductService(service && serviceImplement) 주문상품에   관한 정보를 PATCH 때 Controller의 응답에 대한 데이터 반환

### DIFF
--- a/src/main/java/com/online/shopping_back/dto/response/orderProduct/PatchOrderProductResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/orderProduct/PatchOrderProductResponseDto.java
@@ -1,0 +1,43 @@
+package com.online.shopping_back.dto.response.orderProduct;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.online.shopping_back.dto.response.ResponseCode;
+import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.ResponseMessage;
+
+import lombok.Getter;
+
+@Getter
+public class PatchOrderProductResponseDto extends ResponseDto{
+    
+    private PatchOrderProductResponseDto(String code, String messsage){
+        super(code, messsage);
+    }
+
+    public static ResponseEntity<PatchOrderProductResponseDto> success(){
+        PatchOrderProductResponseDto result = new PatchOrderProductResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+    
+    public static ResponseEntity<ResponseDto> notExistProduct(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_FOUND_PRODUCT, ResponseMessage.NOT_FOUND_PRODUCT);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+    
+    public static ResponseEntity<ResponseDto> notExistOrder(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_ORDER, ResponseMessage.NOT_EXIST_ORDER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }     
+
+    public static ResponseEntity<ResponseDto> notExistOrderProduct(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_FOUND_ORDER_PRODUCT, ResponseMessage.NOT_FOUND_ORDER_PRODUCT);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }        
+}

--- a/src/main/java/com/online/shopping_back/service/OrderProductService.java
+++ b/src/main/java/com/online/shopping_back/service/OrderProductService.java
@@ -2,13 +2,16 @@ package com.online.shopping_back.service;
 
 import org.springframework.http.ResponseEntity;
 
+import com.online.shopping_back.dto.request.orderProduct.PatchOrderProductRequestDto;
 import com.online.shopping_back.dto.request.orderProduct.PostOrderProductRequestDto;
 import com.online.shopping_back.dto.response.orderProduct.PostOrderProductResponseDto;
+
+import com.online.shopping_back.dto.response.orderProduct.PatchOrderProductResponseDto;
 
 public interface OrderProductService {
 
     
     ResponseEntity<? super PostOrderProductResponseDto>postOrderProduct(PostOrderProductRequestDto dto, String email, Integer userNumber, Integer orderNumber,Integer productNumber);
-
+    ResponseEntity<? super PatchOrderProductResponseDto> patchOrderProduct(PatchOrderProductRequestDto dto, String email, Integer userNumber, Integer orderNumber,Integer productNumber);
 
 } 

--- a/src/main/java/com/online/shopping_back/service/implement/OrderProductServiceImplement.java
+++ b/src/main/java/com/online/shopping_back/service/implement/OrderProductServiceImplement.java
@@ -3,10 +3,15 @@ package com.online.shopping_back.service.implement;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import com.online.shopping_back.dto.request.orderProduct.PostOrderProductRequestDto;
 import com.online.shopping_back.dto.response.ResponseDto;
+
+import com.online.shopping_back.dto.request.orderProduct.PatchOrderProductRequestDto;
+import com.online.shopping_back.dto.request.orderProduct.PostOrderProductRequestDto;
+
+import com.online.shopping_back.dto.response.orderProduct.PatchOrderProductResponseDto;
 import com.online.shopping_back.dto.response.orderProduct.PostOrderProductResponseDto;
 import com.online.shopping_back.dto.response.product.PatchProductResponseDto;
+
 import com.online.shopping_back.entity.BuyEntity;
 import com.online.shopping_back.entity.OrderProductEntity;
 import com.online.shopping_back.entity.ProductEntity;
@@ -54,6 +59,33 @@ public class OrderProductServiceImplement implements OrderProductService{
             return ResponseDto.databaseError();
         }
         return PostOrderProductResponseDto.success();
+    }
+
+    @Override
+    public ResponseEntity<? super PatchOrderProductResponseDto> patchOrderProduct(PatchOrderProductRequestDto dto,
+            String email, Integer userNumber, Integer orderNumber, Integer productNumber) {
+        
+        try {
+            boolean existedUser = userRepository.existsByEmail(email);
+            if(!existedUser) return PatchOrderProductResponseDto.notExistUser();
+
+            ProductEntity productEntity = productRepository.findByProductNumber(productNumber);
+            if(productEntity == null) return PatchOrderProductResponseDto.notExistProduct();
+
+            boolean existedOrder = buyRepository.existsByOrderNumber(orderNumber);
+            if(!existedOrder) return PatchOrderProductResponseDto.notExistOrder();
+
+            OrderProductEntity orderProductEntity = orderProductRepository.findByOrderProductNumber(dto.getOrderProductNumber());
+            if(orderProductEntity == null) return PatchOrderProductResponseDto.notExistOrderProduct();
+
+            orderProductEntity.patchOrderProduct(dto);
+            orderProductRepository.save(orderProductEntity);            
+
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            return ResponseDto.databaseError();
+        }        
+        return PatchOrderProductResponseDto.success();        
     }
 
     


### PR DESCRIPTION
PatchOrderProductResponseDto생성 및 주문 상품 정보 수정시 실패와 성공에 대한 객체 생성 및 성공시 식별자를 통해 정보를 찾아 DB 주문 상품  테이블에 정보 수정

OrderProductService(service && serviceImplement)  -- 주문 상품 작성시  patchOrderProduct()  이용한 Controller의 응답에 대한 데이터 비즈니스 로직에 따른 실패할 떄 각각  응답에 대한 코드와 메시지 생성  성공할 때는  db에서 주문 상품 번호를 찾아 수정  및 저장