### PR TITLE
Feat  BuyController controller :  주문 에 관한정보를  작성 하기 위한 controller에   POST Method  추가        PatchOrderResponseDto: 응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/online/shopping_back/controller/BuyController.java
+++ b/src/main/java/com/online/shopping_back/controller/BuyController.java
@@ -1,0 +1,55 @@
+package com.online.shopping_back.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.online.shopping_back.dto.request.order.PostOrderRequestDto;
+import com.online.shopping_back.dto.response.order.PostOrderResponseDto;
+import com.online.shopping_back.service.BuyService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/buy")
+@RequiredArgsConstructor
+public class BuyController {
+    
+    private final BuyService  buyService;
+
+
+
+
+
+
+
+
+    @PostMapping("/{userNumber}")
+    public ResponseEntity<? super PostOrderResponseDto> postBuy(
+        @RequestBody @Valid PostOrderRequestDto dto,
+        @AuthenticationPrincipal String managerEmail,
+        @PathVariable("userNumber") Integer userNumber        
+    ){
+        ResponseEntity<? super PostOrderResponseDto> response = buyService.postBuy(dto, managerEmail, userNumber);
+        return response;
+    }
+
+
+
+
+
+
+
+
+    
+}

--- a/src/main/java/com/online/shopping_back/dto/response/order/PatchOrderResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/order/PatchOrderResponseDto.java
@@ -1,0 +1,34 @@
+package com.online.shopping_back.dto.response.order;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.online.shopping_back.dto.response.ResponseCode;
+import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.ResponseMessage;
+
+import lombok.Getter;
+
+@Getter
+public class PatchOrderResponseDto extends ResponseDto{
+    
+    private PatchOrderResponseDto(String code, String messsage){
+        super(code, messsage);
+    }
+
+    public static ResponseEntity<PatchOrderResponseDto> success(){
+        PatchOrderResponseDto result = new PatchOrderResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }        
+
+    public static ResponseEntity<ResponseDto> notExistOrder(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_ORDER, ResponseMessage.NOT_EXIST_ORDER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+
+}


### PR DESCRIPTION
BuyController - 주문상품   정보에 대한 PostMapping에  경로 설정 및 postBuy기능을  이용해 서비스 레이어 호출하여 성공일 떄 만 db에 있는 주문테이블 데이터 추가 & 저장 및   실패와 성공에 대해서결과(코드, 메시지)를  클라이언트에게 응답하기

PatchOrderResponseDto
PatchOrderResponseDto생성 및 주문상품 작성시 실패와 성공에 대한 객체 생성 