### PR TITLE
Feat  :  GetOrderResponseDto 응답 데이터를 전달하기 위한 데이터 전송 객체생성

### DIFF
--- a/src/main/java/com/online/shopping_back/dto/response/order/GetOrderResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/order/GetOrderResponseDto.java
@@ -1,0 +1,48 @@
+package com.online.shopping_back.dto.response.order;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.online.shopping_back.dto.response.ResponseCode;
+import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.ResponseMessage;
+import com.online.shopping_back.entity.BuyEntity;
+
+import lombok.Getter;
+
+@Getter
+public class GetOrderResponseDto extends ResponseDto{
+    
+    private int orderNumber;   
+    private int userNumber;
+    private String productName;    
+    private LocalDateTime orderDatetime;
+    private int orderTotalPrice;
+
+    private GetOrderResponseDto(String code, String message,BuyEntity buyEntity){
+        super(code, message);
+        this.orderNumber = buyEntity.getOrderNumber();
+        this.userNumber = buyEntity.getUserNumber();
+        this.productName = buyEntity.getProductName();
+        this.orderDatetime = buyEntity.getOrderDatetime();
+        this.orderTotalPrice = buyEntity.getOrderTotalPrice();
+    }
+
+    public static ResponseEntity<GetOrderResponseDto> success(BuyEntity buyEntity){
+        GetOrderResponseDto result = new GetOrderResponseDto(ResponseCode.SUCCESS,ResponseMessage.SUCCESS,buyEntity);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistUser() {
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }
+    
+    public static ResponseEntity<ResponseDto> notExistOrder(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_ORDER, ResponseMessage.NOT_EXIST_ORDER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }       
+
+}


### PR DESCRIPTION
 GetOrderResponseDto 생성 및 주문 정보 읽기시 실패와 성공에 대한  데이터 전송 객체(코드 및 메시지) 생성  및 성공시에만  DB 주문  테이블에 회원 번호 에 해당되는  정보 가져오기