### PR TITLE
Feat :  DeletePayResponseDto응답 데이터를 전달하기 위한 데이터 전송 객체생성 / PayService(service && serviceImplement) 결제   에   관한 정보를 삭제시 Controller의 응답에 대한 데이터 반환

### DIFF
--- a/src/main/java/com/online/shopping_back/dto/response/pay/DeletePayResponseDto.java
+++ b/src/main/java/com/online/shopping_back/dto/response/pay/DeletePayResponseDto.java
@@ -1,0 +1,35 @@
+package com.online.shopping_back.dto.response.pay;
+
+import com.online.shopping_back.dto.response.ResponseCode;
+import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.ResponseMessage;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Getter;
+
+@Getter
+public class DeletePayResponseDto extends ResponseDto{
+    
+    private DeletePayResponseDto(String code, String messsage){
+        super(code, messsage);
+    }
+
+    public static ResponseEntity<DeletePayResponseDto> success(){
+        DeletePayResponseDto result = new DeletePayResponseDto(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> notExistOrder(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_EXIST_ORDER, ResponseMessage.NOT_EXIST_ORDER);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }   
+    
+    public static ResponseEntity<ResponseDto> notExistPay(){
+        ResponseDto result = new ResponseDto(ResponseCode.NOT_FOUND_PAY, ResponseMessage.NOT_FOUND_PAY);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(result);
+    }    
+
+}

--- a/src/main/java/com/online/shopping_back/service/PayService.java
+++ b/src/main/java/com/online/shopping_back/service/PayService.java
@@ -4,11 +4,13 @@ import org.springframework.http.ResponseEntity;
 
 import com.online.shopping_back.dto.request.pay.PatchPayRequestDto;
 import com.online.shopping_back.dto.request.pay.PostPayRequestDto;
+import com.online.shopping_back.dto.response.pay.DeletePayResponseDto;
 import com.online.shopping_back.dto.response.pay.PatchPayResponseDto;
 import com.online.shopping_back.dto.response.pay.PostPayResponseDto;
 
 public interface PayService {
     
-    ResponseEntity<? super  PostPayResponseDto> postPay(PostPayRequestDto dto,String email,Integer userNumber, Integer orderNumber);
-    ResponseEntity<? super PatchPayResponseDto> patchPay(PatchPayRequestDto dto, String email,Integer userNumber, Integer orderNumber);        
+    ResponseEntity<? super PostPayResponseDto> postPay(PostPayRequestDto dto,String email,Integer userNumber, Integer orderNumber);
+    ResponseEntity<? super PatchPayResponseDto> patchPay(PatchPayRequestDto dto, String email,Integer userNumber, Integer orderNumber);  
+    ResponseEntity<? super DeletePayResponseDto> deletePay(String email,Integer userNumber, Integer orderNumber, Integer payNumber);
 }

--- a/src/main/java/com/online/shopping_back/service/implement/PayServiceImplement.java
+++ b/src/main/java/com/online/shopping_back/service/implement/PayServiceImplement.java
@@ -4,6 +4,7 @@ import com.online.shopping_back.dto.request.pay.PatchPayRequestDto;
 import com.online.shopping_back.dto.request.pay.PostPayRequestDto;
 
 import com.online.shopping_back.dto.response.ResponseDto;
+import com.online.shopping_back.dto.response.pay.DeletePayResponseDto;
 import com.online.shopping_back.dto.response.pay.PatchPayResponseDto;
 import com.online.shopping_back.dto.response.pay.PostPayResponseDto;
 
@@ -73,6 +74,29 @@ public class PayServiceImplement implements PayService{
             return ResponseDto.databaseError();
         }
         return PatchPayResponseDto.success();
+    }
+
+    @Override
+    public ResponseEntity<? super DeletePayResponseDto> deletePay(String email, Integer userNumber, Integer orderNumber,Integer payNumber) {
+        
+        try {
+
+            boolean existedUser = userRepository.existsByEmail(email);
+            if(!existedUser) return PatchPayResponseDto.notExistUser();
+
+            boolean existedOrder = buyRepository.existsByOrderNumber(orderNumber);
+            if(!existedOrder) return PatchPayResponseDto.notExistOrder();         
+            
+            PayEntity  payEntity = payRepository.findByPayNumber(payNumber);
+            if(payEntity == null) return DeletePayResponseDto.notExistPay();
+
+            payRepository.delete(payEntity);
+            
+        } catch (Exception exception) {
+            exception.printStackTrace();
+            return ResponseDto.databaseError();
+        }
+        return DeletePayResponseDto.success();
     }
 
     


### PR DESCRIPTION
DeletePayResponseDto  - 결제정보 삭제 시 실패와 성공에 대한 데이터 전송 객체(코드 및 메시지) 생성 및 성공시에만  DB 결제  테이블에 결제번호에 해당되는 정보 삭제하기 

PayService(service && serviceImplement)  - 결제 정보 삭제시  deletePay()  이용한 Controller의 응답에 대한 비즈니스 로직에 따른 성공과 실패할 때 각각  응답에 대한 코드와 메시지 생성  성공시에는   db에 결제번호에 해당되는 정보 수정 